### PR TITLE
Fix build-time inlining of ggplot2 functions

### DIFF
--- a/R/ggstance.R
+++ b/R/ggstance.R
@@ -3,7 +3,9 @@
 #'   segmentsGrob
 #' @import ggplot2
 generate <- function(fn) {
-  get(fn, -1, environment(ggplot_build))
+  function(...) {
+    get(fn, -1, environment(ggplot_build))(...)
+  }
 }
 
 ggname <- function(prefix, grob) {


### PR DESCRIPTION
I believe this should be enough to silence the `cli::` import warnings with the dev version of ggplot2