### PR TITLE
Add missing 'quantreg' to Suggests

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,6 +23,7 @@ Imports:
 Suggests:
     covr,
     Hmisc,
+    quantreg,
     testthat,
     vdiffr (>= 1.0.4)
 URL: https://github.com/lionel-/ggstance

--- a/R/stat-boxploth.R
+++ b/R/stat-boxploth.R
@@ -51,6 +51,9 @@ StatBoxploth <- ggproto("StatBoxploth", Stat,
     qs <- c(0, 0.25, 0.5, 0.75, 1)
 
     if (!is.null(data$weight)) {
+      if (!requireNamespace("quantreg", quietly = TRUE)) {
+        stop("'quantreg' is required for compute_group() with weights")
+      }
       mod <- quantreg::rq(x ~ 1, weights = weight, data = data, tau = qs)
       stats <- as.numeric(stats::coef(mod))
     } else {


### PR DESCRIPTION
Not sure why `R CMD check` doesn't appear to pick this up, but `tools:::.check_packages_used()` does