### PR TITLE
Update failing test expectation

### DIFF
--- a/tests/testthat/_snaps/flip.md
+++ b/tests/testthat/_snaps/flip.md
@@ -8,17 +8,17 @@
       ! Problem while setting up geom.
       i Error occurred in the 1st layer.
       Caused by error in `compute_geom_1()`:
-      ! `geom_linerangeh()` requires the following missing aesthetics: y, xmin, and xmax
+      ! `geom_linerangeh()` requires the following missing aesthetics: y, xmin, and xmax.
 
 # flipped stats have correct `required_aes` failure messages
 
     Code
-      (expect_error(ggplot_build(p), "y$"))
+      (expect_error(ggplot_build(p), "y$|y\\.$"))
     Output
       <error/rlang_error>
       Error in `stat_binh()`:
       ! Problem while computing stat.
       i Error occurred in the 1st layer.
       Caused by error in `compute_layer()`:
-      ! `stat_binh()` requires the following missing aesthetics: y
+      ! `stat_binh()` requires the following missing aesthetics: y.
 

--- a/tests/testthat/test-flip.R
+++ b/tests/testthat/test-flip.R
@@ -13,6 +13,6 @@ test_that("flipped geoms have correct `required_aes` failure messages", {
 test_that("flipped stats have correct `required_aes` failure messages", {
   p <- ggplot(mtcars) + stat_binh(bins = 30)
   expect_snapshot({
-    (expect_error(ggplot_build(p), "y$"))
+    (expect_error(ggplot_build(p), "y$|y\\.$"))
   })
 })


### PR DESCRIPTION
This PR aims to fix #44 or the current CRAN failure observed at https://cran.r-project.org/web/checks/check_results_ggstance.html.
There are a few warnings while running the tests, but these do not seem to be the cause of the failure.
It appears that a straightforward snapshot test needs an update because ggplot2 included a period at the end of an error message. This PR updates that test.

